### PR TITLE
Added installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,3 +40,10 @@ Usage in Django:
             FAILED = -1, 'Processing Failed'
 
         status = models.IntegerField(choices=list(STATUS), default=STATUS.NEW)
+
+Installation
+------------
+
+.. code-block::
+
+    pip install labeled-enum


### PR DESCRIPTION
I couldn't figure out why `pip install labeled-enums` wasn't working then saw the package name is singular form.  An installation line might help avoid this confusion with folks.

Note: I couldn't seem to find any resources listing the available supported `code-block` sytnaxes, not sure if there was one for command line / shell.